### PR TITLE
Updated version in nabo/nabo.h to 1.0.5

### DIFF
--- a/nabo/nabo.h
+++ b/nabo/nabo.h
@@ -210,9 +210,9 @@ namespace Nabo
 	//@{
 	
 	//! version of the Nabo library as string
-	#define NABO_VERSION "1.0.4"
+	#define NABO_VERSION "1.0.5"
 	//! version of the Nabo library as an int
-	#define NABO_VERSION_INT 10004
+	#define NABO_VERSION_INT 10005
 	
 	//! Parameter vector
 	struct Parameters: public std::map<std::string, boost::any>


### PR DESCRIPTION
Please only merge if appropriate. 

I'm not sure how the version concept is for libnabo, but to me it looks inconsistent that the package.xml and changlog are on 1.0.5 while the code still declaring itself as 1.0.4. 
This also affects the version libnaboConfigVersion.cmake : it is currently found as 1.0.4.
