### PR TITLE
Release/1.0.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package libnabo
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+1.0.6 (2015-03-05)
+------------------
 * Reset point indices of results with distances exceeding threshold (#23, #24)
 * Fine tune the find_package() capability and add uninstall target (#22)
 * Fixed compiler warning (#18)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog for package libnabo
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Reset point indices of results with distances exceeding threshold (#23, #24)
+* Fine tune the find_package() capability and add uninstall target (#22)
+* Fixed compiler warning (#18)
+* Added OpenMP support (#20, #21)
+* Build type tuning (#19)
+* Fix: terminal comma in enum requires C++11
+* Fix UBSAN error calculating maxNodeCount (#16, #17)
+* Fixed tiny (yet significant) error in the Python doc strings (#15)
+* Compile static lib with PIC (#14)
+* Contributors: Francois Pomerleau, François Pomerleau, Gregory Hitz, Gregory Jefferis, Simon Lynen, Stéphane Magnenat
+
 1.0.5 (2014-06-12)
 ------------------
 * Added configure scripts for full catkinization

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>libnabo</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>
     libnabo is a fast K Nearest Neighbour library for low-dimensional spaces.
   </description>


### PR DESCRIPTION
I would strongly suggest to do a fast-forward here instead of a merge! 
I expect history ugliness and maybe even troubles (with some deployment tools) if the tag is pointing to second parent of a merge commit :). Or am I wrong?

And don't forget to copy or recreate the new tag 1.0.6.