### PR TITLE
removed all code dealing with libnaboTargets.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,9 +119,6 @@ else(SHARED_LIBS)
 endif(SHARED_LIBS)
 set_target_properties(${LIB_NAME} PROPERTIES VERSION "${PROJECT_VERSION}" SOVERSION 1)
 
-export(TARGETS ${LIB_NAME}
-  FILE "${PROJECT_BINARY_DIR}/libnaboTargets.cmake")
-
 # create doc before installing
 set(DOC_INSTALL_TARGET "share/doc/${PROJECT_NAME}/api" CACHE STRING "Target where to install doxygen documentation")
 add_dependencies(${LIB_NAME} doc)
@@ -187,7 +184,6 @@ configure_file(libnaboConfigVersion.cmake.in
 install(FILES
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/libnaboConfig.cmake"
   "${PROJECT_BINARY_DIR}/libnaboConfigVersion.cmake"
-  "${PROJECT_BINARY_DIR}/libnaboTargets.cmake"
   DESTINATION share/libnabo/cmake COMPONENT dev)
 
 

--- a/libnaboConfig.cmake.in
+++ b/libnaboConfig.cmake.in
@@ -6,13 +6,7 @@
 # Compute paths
 get_filename_component(libnabo_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 set(libnabo_INCLUDE_DIRS "@libnabo_include_dirs@")
- 
-# Our library dependencies (contains definitions for IMPORTED targets)
-if(NOT TARGET @LIB_NAME@ AND NOT libnabo_BINARY_DIR)
-  include("${libnabo_CMAKE_DIR}/libnaboTargets.cmake")
-endif()
- 
-# These are IMPORTED targets created by libnaboTargets.cmake
+
 if (CMAKE_COMPILER_IS_GNUCC)
   set(libnabo_LIBRARIES @libnabo_library@ gomp)
 else(CMAKE_COMPILER_IS_GNUCC)


### PR DESCRIPTION
(addressing #31)

According to http://www.cmake.org/cmake/help/v3.0/command/export.html it is wrong to install target files. But did it have it's purpose, nevertheless? Or is it just fine to be removed? (As suggested with this PR).

Any ideas, what the removed code could be (still) important for?
(btw. it was introduced in 310e9bd50c77a1c255f59156c3b329ab209e8dcf and apparently not touched anymore later)

Please, don't merge until the theory that we don't need the targets file at all has been sufficiently tested.