### PR TITLE
Disallow instantiation with non dynamic matrices.

### DIFF
--- a/nabo/nabo.h
+++ b/nabo/nabo.h
@@ -367,32 +367,32 @@ namespace Nabo
 		
 
 
-    //! Prevent creation of trees with the wrong matrix type. Currently only dynamic size matrices are supported.
-    template <typename WrongMatrixType>
-    static NearestNeighbourSearch* create(const WrongMatrixType& cloud, const Index dim = std::numeric_limits<Index>::max(), const SearchType preferedType = KDTREE_LINEAR_HEAP, const unsigned creationOptionFlags = 0, const Parameters& additionalParameters = Parameters())
-    {
-      typedef int Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef[sizeof(WrongMatrixType) > 0 ? -1 : 1];
-      Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef dummy;
-      return NULL;
-    }
+		//! Prevent creation of trees with the wrong matrix type. Currently only dynamic size matrices are supported.
+		template <typename WrongMatrixType>
+		static NearestNeighbourSearch* create(const WrongMatrixType& cloud, const Index dim = std::numeric_limits<Index>::max(), const SearchType preferedType = KDTREE_LINEAR_HEAP, const unsigned creationOptionFlags = 0, const Parameters& additionalParameters = Parameters())
+		{
+		  typedef int Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef[sizeof(WrongMatrixType) > 0 ? -1 : 1];
+		  Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef dummy;
+		  return NULL;
+		}
 
-    //! Prevent creation of trees with the wrong matrix type. Currently only dynamic size matrices are supported.
-    template <typename WrongMatrixType>
-    static NearestNeighbourSearch* createBruteForce(const WrongMatrixType& cloud, const Index dim = std::numeric_limits<Index>::max(), const unsigned creationOptionFlags = 0)
-    {
-      typedef int Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef[sizeof(WrongMatrixType) > 0 ? -1 : 1];
-      Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef dummy;
-      return NULL;
-    }
+		//! Prevent creation of trees with the wrong matrix type. Currently only dynamic size matrices are supported.
+		template <typename WrongMatrixType>
+		static NearestNeighbourSearch* createBruteForce(const WrongMatrixType& cloud, const Index dim = std::numeric_limits<Index>::max(), const unsigned creationOptionFlags = 0)
+		{
+		  typedef int Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef[sizeof(WrongMatrixType) > 0 ? -1 : 1];
+		  Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef dummy;
+		  return NULL;
+		}
 
-    //! Prevent creation of trees with the wrong matrix type. Currently only dynamic size matrices are supported.
-    template <typename WrongMatrixType>
-    static NearestNeighbourSearch* createKDTreeLinearHeap(const WrongMatrixType& cloud, const Index dim = std::numeric_limits<Index>::max(), const unsigned creationOptionFlags = 0, const Parameters& additionalParameters = Parameters())
-    {
-      typedef int Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef[sizeof(WrongMatrixType) > 0 ? -1 : 1];
-      Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef dummy;
-      return NULL;
-    }
+		//! Prevent creation of trees with the wrong matrix type. Currently only dynamic size matrices are supported.
+		template <typename WrongMatrixType>
+		static NearestNeighbourSearch* createKDTreeLinearHeap(const WrongMatrixType& cloud, const Index dim = std::numeric_limits<Index>::max(), const unsigned creationOptionFlags = 0, const Parameters& additionalParameters = Parameters())
+		{
+		  typedef int Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef[sizeof(WrongMatrixType) > 0 ? -1 : 1];
+		  Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef dummy;
+		  return NULL;
+		}
 
 		//! Prevent creation of trees with the wrong matrix type. Currently only dynamic size matrices are supported.
 		template <typename WrongMatrixType>

--- a/nabo/nabo.h
+++ b/nabo/nabo.h
@@ -365,6 +365,44 @@ namespace Nabo
 		 * 	\return an object on which to run nearest neighbour queries */
 		static NearestNeighbourSearch* createKDTreeTreeHeap(const Matrix& cloud, const Index dim = std::numeric_limits<Index>::max(), const unsigned creationOptionFlags = 0, const Parameters& additionalParameters = Parameters());
 		
+
+
+    //! Prevent creation of trees with the wrong matrix type. Currently only dynamic size matrices are supported.
+    template <typename WrongMatrixType>
+    static NearestNeighbourSearch* create(const WrongMatrixType& cloud, const Index dim = std::numeric_limits<Index>::max(), const SearchType preferedType = KDTREE_LINEAR_HEAP, const unsigned creationOptionFlags = 0, const Parameters& additionalParameters = Parameters())
+    {
+      typedef int Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef[sizeof(WrongMatrixType) > 0 ? -1 : 1];
+      Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef dummy;
+      return NULL;
+    }
+
+    //! Prevent creation of trees with the wrong matrix type. Currently only dynamic size matrices are supported.
+    template <typename WrongMatrixType>
+    static NearestNeighbourSearch* createBruteForce(const WrongMatrixType& cloud, const Index dim = std::numeric_limits<Index>::max(), const unsigned creationOptionFlags = 0)
+    {
+      typedef int Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef[sizeof(WrongMatrixType) > 0 ? -1 : 1];
+      Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef dummy;
+      return NULL;
+    }
+
+    //! Prevent creation of trees with the wrong matrix type. Currently only dynamic size matrices are supported.
+    template <typename WrongMatrixType>
+    static NearestNeighbourSearch* createKDTreeLinearHeap(const WrongMatrixType& cloud, const Index dim = std::numeric_limits<Index>::max(), const unsigned creationOptionFlags = 0, const Parameters& additionalParameters = Parameters())
+    {
+      typedef int Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef[sizeof(WrongMatrixType) > 0 ? -1 : 1];
+      Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef dummy;
+      return NULL;
+    }
+
+		//! Prevent creation of trees with the wrong matrix type. Currently only dynamic size matrices are supported.
+		template <typename WrongMatrixType>
+		static NearestNeighbourSearch* createKDTreeTreeHeap(const WrongMatrixType&, const Index dim = std::numeric_limits<Index>::max(), const unsigned creationOptionFlags = 0, const Parameters& additionalParameters = Parameters())
+		{
+		  typedef int Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef[sizeof(WrongMatrixType) > 0 ? -1 : 1];
+		  Please_make_sure_that_the_decltype_of_the_first_parameter_is_equal_to_the_Matrix_typedef dummy;
+		  return NULL;
+		}
+
 		//! virtual destructor
 		virtual ~NearestNeighbourSearch() {}
 		

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,10 +82,10 @@ add_executable(knnbucketsize knnbucketsize.cpp)
 target_link_libraries(knnbucketsize ${LIB_NAME} ${EXTRA_LIBS} ${Boost_LIBRARIES})
 
 # Ensure that users cannot instantiate a tree with wrong matrix types.
-macro(try_compile_disallowed_types MAT_TYPE TREE_TYPE EXPECT)
+macro(try_compile_cloud_types MAT_TYPE TREE_TYPE EXPECT)
   try_compile(COMPILE_SUCCEEDED
                 "${CMAKE_CURRENT_BINARY_DIR}"
-                "${CMAKE_CURRENT_SOURCE_DIR}/invalid_matrix_types_disallowed.cpp"
+                "${CMAKE_CURRENT_SOURCE_DIR}/invalid_matrix_types.cpp"
                 COMPILE_DEFINITIONS "-D${MAT_TYPE} -D${TREE_TYPE} -I${CMAKE_CURRENT_SOURCE_DIR}/../ -I${EIGEN_INCLUDE_DIR} -l${LIB_NAME}"
                 CMAKE_FLAGS "-DCMAKE_CXX_LINK_EXECUTABLE='echo not linking now...'"
                 OUTPUT_VARIABLE OUTPUT)
@@ -100,14 +100,14 @@ macro(try_compile_disallowed_types MAT_TYPE TREE_TYPE EXPECT)
     endif()
   endif()
 
-endmacro(try_compile_disallowed_types)
+endmacro(try_compile_cloud_types)
 
-try_compile_disallowed_types(NABO_EIGEN_DYNAMIC_TYPE, NABO_TYPE_CREATE, TRUE)
-try_compile_disallowed_types(NABO_EIGEN_DYNAMIC_TYPE, NABO_TYPE_BRUTE_FORCE, TRUE)
-try_compile_disallowed_types(NABO_EIGEN_DYNAMIC_TYPE, NABO_TYPE_LINEAR_HEAP, TRUE)
-try_compile_disallowed_types(NABO_EIGEN_DYNAMIC_TYPE, NABO_TYPE_TREE_HEAP, TRUE)
+try_compile_cloud_types(NABO_EIGEN_DYNAMIC_TYPE, NABO_TYPE_CREATE, TRUE)
+try_compile_cloud_types(NABO_EIGEN_DYNAMIC_TYPE, NABO_TYPE_BRUTE_FORCE, TRUE)
+try_compile_cloud_types(NABO_EIGEN_DYNAMIC_TYPE, NABO_TYPE_LINEAR_HEAP, TRUE)
+try_compile_cloud_types(NABO_EIGEN_DYNAMIC_TYPE, NABO_TYPE_TREE_HEAP, TRUE)
 
-try_compile_disallowed_types(NABO_EIGEN_SEMI_DYNAMIC_TYPE, NABO_TYPE_CREATE, FALSE)
-try_compile_disallowed_types(NABO_EIGEN_SEMI_DYNAMIC_TYPE, NABO_TYPE_BRUTE_FORCE, FALSE)
-try_compile_disallowed_types(NABO_EIGEN_SEMI_DYNAMIC_TYPE, NABO_TYPE_LINEAR_HEAP, FALSE)
-try_compile_disallowed_types(NABO_EIGEN_SEMI_DYNAMIC_TYPE, NABO_TYPE_TREE_HEAP, FALSE)
+try_compile_cloud_types(NABO_EIGEN_SEMI_DYNAMIC_TYPE, NABO_TYPE_CREATE, FALSE)
+try_compile_cloud_types(NABO_EIGEN_SEMI_DYNAMIC_TYPE, NABO_TYPE_BRUTE_FORCE, FALSE)
+try_compile_cloud_types(NABO_EIGEN_SEMI_DYNAMIC_TYPE, NABO_TYPE_LINEAR_HEAP, FALSE)
+try_compile_cloud_types(NABO_EIGEN_SEMI_DYNAMIC_TYPE, NABO_TYPE_TREE_HEAP, FALSE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,3 +80,34 @@ target_link_libraries(knnepsilon ${LIB_NAME} ${EXTRA_LIBS} ${Boost_LIBRARIES})
 
 add_executable(knnbucketsize knnbucketsize.cpp)
 target_link_libraries(knnbucketsize ${LIB_NAME} ${EXTRA_LIBS} ${Boost_LIBRARIES})
+
+# Ensure that users cannot instantiate a tree with wrong matrix types.
+macro(try_compile_disallowed_types MAT_TYPE TREE_TYPE EXPECT)
+  try_compile(COMPILE_SUCCEEDED
+                "${CMAKE_CURRENT_BINARY_DIR}"
+                "${CMAKE_CURRENT_SOURCE_DIR}/invalid_matrix_types_disallowed.cpp"
+                COMPILE_DEFINITIONS "-D${MAT_TYPE} -D${TREE_TYPE} -I${CMAKE_CURRENT_SOURCE_DIR}/../ -I${EIGEN_INCLUDE_DIR} -l${LIB_NAME}"
+                CMAKE_FLAGS "-DCMAKE_CXX_LINK_EXECUTABLE='echo not linking now...'"
+                OUTPUT_VARIABLE OUTPUT)
+
+  if (${EXPECT} STREQUAL "TRUE") 
+    if(NOT COMPILE_SUCCEEDED)
+      message( FATAL_ERROR "Compiling a test executable failed." )
+    endif()
+  else()
+    if(COMPILE_SUCCEEDED)
+      message( FATAL_ERROR "Tried to instantiate nabo-search trees with non-allowed types and succeeded. This is an error. Message ${OUTPUT}" )
+    endif()
+  endif()
+
+endmacro(try_compile_disallowed_types)
+
+try_compile_disallowed_types(NABO_EIGEN_DYNAMIC_TYPE, NABO_TYPE_CREATE, TRUE)
+try_compile_disallowed_types(NABO_EIGEN_DYNAMIC_TYPE, NABO_TYPE_BRUTE_FORCE, TRUE)
+try_compile_disallowed_types(NABO_EIGEN_DYNAMIC_TYPE, NABO_TYPE_LINEAR_HEAP, TRUE)
+try_compile_disallowed_types(NABO_EIGEN_DYNAMIC_TYPE, NABO_TYPE_TREE_HEAP, TRUE)
+
+try_compile_disallowed_types(NABO_EIGEN_SEMI_DYNAMIC_TYPE, NABO_TYPE_CREATE, FALSE)
+try_compile_disallowed_types(NABO_EIGEN_SEMI_DYNAMIC_TYPE, NABO_TYPE_BRUTE_FORCE, FALSE)
+try_compile_disallowed_types(NABO_EIGEN_SEMI_DYNAMIC_TYPE, NABO_TYPE_LINEAR_HEAP, FALSE)
+try_compile_disallowed_types(NABO_EIGEN_SEMI_DYNAMIC_TYPE, NABO_TYPE_TREE_HEAP, FALSE)

--- a/tests/invalid_matrix_types.cpp
+++ b/tests/invalid_matrix_types.cpp
@@ -38,36 +38,36 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 template <typename MatrixType>
 int testFunction()
 {
-  MatrixType M = MatrixType::Random(3, 100);
-  MatrixType q = MatrixType::Random(3, 5);
+	MatrixType M = MatrixType::Random(3, 100);
+	MatrixType q = MatrixType::Random(3, 5);
 
 #ifdef NABO_TYPE_CREATE
-  Nabo::NNSearchF* nns = Nabo::NNSearchF::create(M);
+	Nabo::NNSearchF* nns = Nabo::NNSearchF::create(M);
 #endif  // NABO_TYPE_CREATE
 
 #ifdef NABO_TYPE_BRUTE_FORCE
-  Nabo::NNSearchF* nns = Nabo::NNSearchF::createBruteForce(M);
+	Nabo::NNSearchF* nns = Nabo::NNSearchF::createBruteForce(M);
 #endif  // NABO_TYPE_BRUTE_FORCE
 
 #ifdef NABO_TYPE_LINEAR_HEAP
-  Nabo::NNSearchF* nns = Nabo::NNSearchF::createKDTreeLinearHeap(M);
+	Nabo::NNSearchF* nns = Nabo::NNSearchF::createKDTreeLinearHeap(M);
 #endif  // NABO_TYPE_TREE_HEAP
 
 #ifdef NABO_TYPE_TREE_HEAP
-  Nabo::NNSearchF* nns = Nabo::NNSearchF::createKDTreeTreeHeap(M);
+	Nabo::NNSearchF* nns = Nabo::NNSearchF::createKDTreeTreeHeap(M);
 #endif  // NABO_TYPE_TREE_HEAP
-  delete nns;
-  return 0;
+	delete nns;
+	return 0;
 }
 int main(int /*argc*/, char** /*argv*/)
 {
   // Ensure that the test as such compiles.
 #ifdef NABO_EIGEN_DYNAMIC_TYPE
-  int value = testFunction<Eigen::MatrixXf>();
+	int value = testFunction<Eigen::MatrixXf>();
 #endif  // NABO_EIGEN_DYNAMIC_TYPE
 
 #ifdef NABO_EIGEN_SEMI_DYNAMIC_TYPE
-  int value = testFunction<Eigen::Matrix<float, 5, Eigen::Dynamic> >();
+	int value = testFunction<Eigen::Matrix<float, 5, Eigen::Dynamic> >();
 #endif  // NABO_EIGEN_SEMI_DYNAMIC_TYPE
-  return value;
+	return value;
 }

--- a/tests/invalid_matrix_types_disallowed.cpp
+++ b/tests/invalid_matrix_types_disallowed.cpp
@@ -1,0 +1,73 @@
+/*
+
+Copyright (c) 2015, Simon Lynen, Google Inc.
+You can contact the author at <slynen at google dot com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ETH-ASL BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "nabo/nabo.h"
+
+/*
+ * These tests ensure that the instantiation of Nabo Trees with non-matching
+ * matrix types is not allowed.
+ */
+template <typename MatrixType>
+int testFunction()
+{
+  MatrixType M = MatrixType::Random(3, 100);
+  MatrixType q = MatrixType::Random(3, 5);
+
+#ifdef NABO_TYPE_CREATE
+  Nabo::NNSearchF* nns = Nabo::NNSearchF::create(M);
+#endif  // NABO_TYPE_CREATE
+
+#ifdef NABO_TYPE_BRUTE_FORCE
+  Nabo::NNSearchF* nns = Nabo::NNSearchF::createBruteForce(M);
+#endif  // NABO_TYPE_BRUTE_FORCE
+
+#ifdef NABO_TYPE_LINEAR_HEAP
+  Nabo::NNSearchF* nns = Nabo::NNSearchF::createKDTreeLinearHeap(M);
+#endif  // NABO_TYPE_TREE_HEAP
+
+#ifdef NABO_TYPE_TREE_HEAP
+  Nabo::NNSearchF* nns = Nabo::NNSearchF::createKDTreeTreeHeap(M);
+#endif  // NABO_TYPE_TREE_HEAP
+  delete nns;
+  return 0;
+}
+int main(int /*argc*/, char** /*argv*/)
+{
+  // Ensure that the test as such compiles.
+#ifdef NABO_EIGEN_DYNAMIC_TYPE
+  int value = testFunction<Eigen::MatrixXf>();
+#endif  // NABO_EIGEN_DYNAMIC_TYPE
+
+#ifdef NABO_EIGEN_SEMI_DYNAMIC_TYPE
+  int value = testFunction<Eigen::Matrix<float, 5, Eigen::Dynamic> >();
+#endif  // NABO_EIGEN_SEMI_DYNAMIC_TYPE
+  return value;
+}


### PR DESCRIPTION
Add the suggestion of @HannesSommer to disallow instantiation of non dynamic matrices. Also adds tests for this.

@HannesSommer @tcies ptal