### PR TITLE
Removed instructions how to update to a certain branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,6 @@ The source code is available from github, you can clone the git tree by doing:
 
 	git clone git://github.com/ethz-asl/libnabo.git
 
-You can then checkout a specific branch, for instance to checkout version 1.0.2, do:
-
-	cd libnabo
-	git checkout 1.0.2
 
 Compilation
 ===========


### PR DESCRIPTION
Removed, since this should be common knowledge, and might only be confusing, if one just copy-pastes the instructions.