### PR TITLE
Removed hard dependency on the doc target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,6 @@ set_target_properties(${LIB_NAME} PROPERTIES VERSION "${PROJECT_VERSION}" SOVERS
 
 # create doc before installing
 set(DOC_INSTALL_TARGET "share/doc/${PROJECT_NAME}/api" CACHE STRING "Target where to install doxygen documentation")
-add_dependencies(${LIB_NAME} doc)
 install(FILES nabo/nabo.h DESTINATION include/nabo)
 install(FILES nabo/third_party/any.hpp DESTINATION include/nabo/third_party)
 install(FILES README.md DESTINATION share/doc/${PROJECT_NAME})

--- a/UseDoxygen.cmake
+++ b/UseDoxygen.cmake
@@ -109,10 +109,9 @@ if(DOXYGEN_FOUND AND DOXYFILE_IN_FOUND)
 
 	configure_file(${DOXYFILE_IN} Doxyfile IMMEDIATE @ONLY)
 
-	get_target_property(DOC_TARGET doc TYPE)
-	if(NOT DOC_TARGET)
-		add_custom_target(doc)
-	endif()
+  if(NOT TARGET doc)
+    add_custom_target(doc)
+  endif()
 
 	add_dependencies(doc doxygen)
 endif()

--- a/UseDoxygen.cmake
+++ b/UseDoxygen.cmake
@@ -109,9 +109,9 @@ if(DOXYGEN_FOUND AND DOXYFILE_IN_FOUND)
 
 	configure_file(${DOXYFILE_IN} Doxyfile IMMEDIATE @ONLY)
 
-  if(NOT TARGET doc)
-    add_custom_target(doc)
-  endif()
+	if(NOT TARGET doc)
+		add_custom_target(doc)
+	endif()
 
 	add_dependencies(doc doxygen)
 endif()

--- a/UseDoxygen.cmake
+++ b/UseDoxygen.cmake
@@ -69,7 +69,7 @@ if(DOXYGEN_FOUND AND DOXYFILE_IN_FOUND)
 		ADDITIONAL_MAKE_CLEAN_FILES
 		"${DOXYFILE_OUTPUT_DIR}/${DOXYFILE_HTML_DIR}")
 
-	add_custom_target(doxygen
+	add_custom_target(doxygen ALL
 		COMMAND ${DOXYGEN_EXECUTABLE}
 			${DOXYFILE} 
 		COMMENT "Writing documentation to ${DOXYFILE_OUTPUT_DIR}..."


### PR DESCRIPTION
It is now possible to build the nabo target without generating the documentation. It saves time and avoids missing documentation warnings if libnabo is built as a dependency. The documentation is still generated if one executes `make install` or `make all`.