### PR TITLE
Disable OpenMP by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ if(MSVC AND (MSVC_VERSION LESS 1600))
 endif(MSVC AND (MSVC_VERSION LESS 1600))
 
 # openmp
-set(USE_OPEN_MP TRUE CACHE BOOL "Set to FALSE to not use OpenMP")
+set(USE_OPEN_MP FALSE CACHE BOOL "Set to TRUE to use OpenMP")
 if (USE_OPEN_MP)
 	find_package(OpenMP)
 	if (OPENMP_FOUND)


### PR DESCRIPTION
OpenMP can significantly slow down NN search if the knn function is also running in multiple threads at the same time. It was not straightforward to detect that libnabo was significantly slower (in some cases 20x slower) in that case compared to just using a single threaded version of libnabo. Therefore I suggest, that the parallel option has to be actively set by the user to avoid accidentally slowing down NN search.

I have also experimented with the `num_threads` function to provide an option to disable multithreading at runtime. However, there is still a small overhead with num_threads(1) compared to not compiling with OpenMP.

fyi: @HannesSommer 