### PR TITLE
Generate "${PROJECT_BINARY_DIR}/libnaboConfig.cmake" as well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,12 @@ set(libnabo_library $<TARGET_FILE:${LIB_NAME}>)
 get_property(libnabo_include_dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
 # Configure config file for local build tree
 configure_file(libnaboConfig.cmake.in
-	"${PROJECT_BINARY_DIR}/libnaboConfig.cmake" @ONLY)
+	"${PROJECT_BINARY_DIR}/libnaboConfig.cmake.conf" @ONLY)
+
+file(GENERATE
+	OUTPUT "${PROJECT_BINARY_DIR}/libnaboConfig.cmake"
+	INPUT "${PROJECT_BINARY_DIR}/libnaboConfig.cmake.conf")
+
 
 # 2- installation build #
 


### PR DESCRIPTION
Setups using the libnaboConfig.cmake in the build folder from outside 
are lacking the nabo target and fail in the generator phase. 

An alternative / superior (?) solution could be to export the nabo 
target.

But I don't have experience with that.

This is a continuation of #65 .