### PR TITLE
Fix compilation warning for MSVC

### DIFF
--- a/nabo/kdtree_cpu.cpp
+++ b/nabo/kdtree_cpu.cpp
@@ -340,7 +340,7 @@ namespace Nabo
 	template<typename T, typename Heap, typename CloudType>
 	unsigned long KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<T, Heap, CloudType>::onePointKnn(const Matrix& query, IndexMatrix& indices, Matrix& dists2, int i, Heap& heap, std::vector<T>& off, const T maxError2, const T maxRadius2, const bool allowSelfMatch, const bool collectStatistics, const bool sortResults) const
 	{
-		fill(off.begin(), off.end(), 0);
+		fill(off.begin(), off.end(), static_cast<T>(0));
 		heap.reset();
 		unsigned long leafTouchedCount(0);
 		


### PR DESCRIPTION
When instantiating the template function fill with float/double, MSVC will emit an warning.

Version: VC++ 14.0.
```
xutility(2766): error C2220: warning treated as error - no 'object' file generated
e:\\google3\\third_party\\msvc\\vc_14_0\\files\\vc\\include\xutility(2780): note: see reference to function template instantiation 'void std::_Fill_unchecked1<_FwdIt,_Ty>(_FwdIt,_FwdIt,const _Ty &,std::false_type)' being compiled
        with
        [
            _FwdIt=float *,
            _Ty=int
        ]
xutility(2788): note: see reference to function template instantiation 'void std::_Fill_unchecked<float*,_Ty>(_FwdIt,_FwdIt,const _Ty &)' being compiled
        with
        [
            _Ty=int,
            _FwdIt=float *
        ]
kdtree_cpu.cpp(344): note: see reference to function template instantiation 'void std::fill<std::_Vector_iterator<std::_Vector_val<std::_Simple_types<float>>>,int>(_FwdIt,_FwdIt,const _Ty &)' being compiled
        with
        [
            _FwdIt=std::_Vector_iterator<std::_Vector_val<std::_Simple_types<float>>>,
            _Ty=int
        ]
kdtree_cpu.cpp(343): note: while compiling class template member function 'unsigned long Nabo::KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<float,Nabo::IndexHeapSTL<int,float>,Eigen::Matrix<float,-1,-1,0,-1,-1>>::onePointKnn(const Eigen::Matrix<float,-1,-1,0,-1,-1> &,Eigen::Matrix<int,-1,-1,0,-1,-1> &,Eigen::Matrix<float,-1,-1,0,-1,-1> &,int,Heap &,std::vector<T,std::allocator<_Ty>> &,const T,const T,const bool,const bool,const bool) const'
        with
        [
            Heap=Nabo::IndexHeapSTL<int,float>,
            T=float,
            _Ty=float
        ]
kdtree_cpu.cpp(452): note: see reference to class template instantiation 'Nabo::KDTreeUnbalancedPtInLeavesImplicitBoundsStackOpt<float,Nabo::IndexHeapSTL<int,float>,Eigen::Matrix<float,-1,-1,0,-1,-1>>' being compiled
xutility(2766): warning C4244: '=': conversion from 'const int' to 'float', possible loss of data
```