### PR TITLE
Remove register keyword in index_heap.h

### DIFF
--- a/nabo/index_heap.h
+++ b/nabo/index_heap.h
@@ -227,7 +227,7 @@ namespace Nabo
 		 * 	\param value new distance value */
 		inline void replaceHead(const Index index, const Value value)
 		{
-			register size_t i = 0;
+			size_t i = 0;
 			for (; i < sizeMinusOne; ++i)
 			{
 				if (data[i + 1].value > value)
@@ -321,7 +321,7 @@ namespace Nabo
 		 * 	\param value new distance value */
 		inline void replaceHead(const Index index, const Value value)
 		{
-			register size_t i;
+			size_t i;
 			for (i = sizeMinusOne; i > 0; --i)
 			{
 				if (data[i-1].value > value)


### PR DESCRIPTION
register keyword has been deprecated. It has no effect in c++11 and was removed in c++17