### PR TITLE
fix for Eigen include error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 build
+.vscode

--- a/nabo/nabo.h
+++ b/nabo/nabo.h
@@ -32,7 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef __NABO_H
 #define __NABO_H
 
-#include "Eigen/Core"
+#include "eigen3/Eigen/Core"
 #if EIGEN_VERSION_AT_LEAST(2,92,0)
 	#define EIGEN3_API
 #endif


### PR DESCRIPTION
Hello, 
I was trying to build a package based on ros2 and respective build system I have to use libnabo for this package so I used it by calling ```#include "nabo/nabo.h"``` but the build crashed with this error message: -
```
/home/shivam/libnabo/libnabo_install_dir/include/nabo/nabo.h:35:10: fatal error: Eigen/Core: No such file or directory
 #include "Eigen/Core"
          ^~~~~~~~~~~~

```
Also, I have been using eigen3 in my projects for a long time so I saw this error to be solved by using the call for eigen3 headers by `#include "eigen3/Eigen/Core"`.

This fix is also supported by this [issue](https://github.com/opencv/opencv/issues/14868) in the opencv repository more specifically this [comment](https://github.com/opencv/opencv/issues/14868#issuecomment-506981686) on the same issue.