### PR TITLE
Automaticaly find eigen3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ find_path(EIGEN_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
   PATHS  Eigen/Core
          /usr/local/include
          /usr/include
-		 /opt/local/include
+         /opt/local/include
   PATH_SUFFIXES include eigen3 eigen2 eigen
   DOC "Directory containing the Eigen3 header files"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,14 +93,15 @@ endif ()
 include(GNUInstallDirs)
 
 # eigen 2 or 3
-find_path(EIGEN_INCLUDE_DIR Eigen/Core
-	/usr/local/include/eigen3
-	/usr/local/include/eigen2
-	/usr/local/include/eigen
-	/usr/include/eigen3
-	/usr/include/eigen2
-	/usr/include/eigen
-	/opt/local/include/eigen3
+find_path(EIGEN_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
+  HINTS  ENV EIGEN3_INC_DIR
+         ENV EIGEN3_DIR
+  PATHS  Eigen/Core
+         /usr/local/include
+         /usr/include
+		 /opt/local/include
+  PATH_SUFFIXES include eigen3 eigen2 eigen
+  DOC "Directory containing the Eigen3 header files"
 )
 
 # optionally, opencl


### PR DESCRIPTION
Now we have to set the CMake variable `EIGEN_INCLUDE_DIR` manually when installing libnabo on Windows.  
It would be simpler to use the environment variable `EIGEN3_INC_DIR` added when installing Eigen.  

To make this changes, I was inspired by the [FindEigen3.cmake](https://github.com/CGAL/cgal/blob/master/Installation/cmake/modules/FindEigen3.cmake) file from CGAL.  
I didn't take the whole file which is very complete and secure, but only the part that find Eigen path.  

I was not able to test these modifications on Linux. So it should be done before merge.  