### PR TITLE
catkin not required for pure cmake packages

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
 	<build_depend>boost</build_depend>
 	<run_depend>eigen</run_depend>
 	<run_depend>boost</run_depend>
+	<run_depend condition="$ROS_VERSION == 1">catkin</run_depend>
 
 	<export>
 		<!-- Specify that this is not really a ROS package -->

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,6 @@
 	<build_depend>boost</build_depend>
 	<run_depend>eigen</run_depend>
 	<run_depend>boost</run_depend>
-	<run_depend>catkin</run_depend>
 
 	<export>
 		<!-- Specify that this is not really a ROS package -->


### PR DESCRIPTION
This prevens rosdep resolving in ROS2