### PR TITLE
Added debug postfix d

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
 	add_definitions(-O3)
 endif()
 
+set(CMAKE_DEBUG_POSTFIX "d")
+
 # Documentation
 option(LIBNABO_BUILD_DOXYGEN "Build libnabo doxygen documentation" ON)
 if (LIBNABO_BUILD_DOXYGEN)


### PR DESCRIPTION
to have separate lib names for debug and release build.
Otherwise the install option of cmakes overwrites the former installation and it is difficult to have debug and release version of the library at the same time.

As mentioned in issue #122 